### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ===============================
-#pyrsync
+# pyrsync
 ===============================
 pyrsync is a Python module which implements the [rsync algorithm] [1], 
 written in pure Python. It *is not* a wrapper for rsync, but a set of 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
