### PR TITLE
fixed installation error in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(name='pyrsync',
       author_email='isis@patternsinthevoid.net',
       url='https://github.com/isislovecruft/pyrsync',
       py_modules=['pyrsync'],
-      license=['MIT'],
+      license='MIT',
       classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Console',


### PR DESCRIPTION
fixed following installation error:

```
Processing c:\users\nils\pycharmprojects\backup-tool\pyrsync
  Preparing metadata (setup.py) ... error
  error: subprocess-exited-with-error

  × python setup.py egg_info did not run successfully.
  │ exit code: 1
  ╰─> [28 lines of output]
      running egg_info
      creating C:\Users\Nils\AppData\Local\Temp\pip-pip-egg-info-fqq0s1ln\pyrsync.egg-info
      Traceback (most recent call last):
        File "<string>", line 2, in <module>
        File "<pip-setuptools-caller>", line 34, in <module>
        File "C:\Users\Nils\PycharmProjects\backup-tool\pyrsync\setup.py", line 26, in <module>
          setup(name='pyrsync',
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\__init__.py", line 155, in setup
          return distutils.core.setup(**attrs)
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\_distutils\core.py", line 148, in setup
          return run_commands(dist)
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\_distutils\core.py", line 163, in run_commands
          dist.run_commands()
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\_distutils\dist.py", line 967, in run_commands
          self.run_command(cmd)
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\_distutils\dist.py", line 986, in run_command
          cmd_obj.run()
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\command\egg_info.py", line 292, in run
          writer(self, ep.name, os.path.join(self.egg_info, ep.name))
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\command\egg_info.py", line 656, in write_pkg_info
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\_distutils\dist.py", line 1118, in write_pkg_info
          self.write_pkg_file(pkg_info)
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\dist.py", line 188, in write_pkg_file
          license = rfc822_escape(self.get_license())
        File "C:\Users\Nils\PycharmProjects\backup-tool\venv\lib\site-packages\setuptools\_distutils\util.py", line 546, in rfc822_escape
          lines = header.split('\n')
      AttributeError: 'list' object has no attribute 'split'
      [end of output]

  note: This error originates from a subprocess, and is likely not a problem with pip.
error: metadata-generation-failed

× Encountered error while generating package metadata.
╰─> See above for output.

note: This is an issue with the package mentioned above, not pip.
hint: See above for details.
```